### PR TITLE
Added cronjob to the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.6
 WORKDIR /app
 ADD . /app
-RUN pip install --requirement ./requirements.txt
+RUN apt-get update && apt-get -y install cron && pip install --requirement ./requirements.txt
 COPY . ./
 ENV DJANGO_SETTINGS_MODULE=world_cup_predictions.settings
+RUN (crontab -l ; echo "00 22 * * * python update_users_scores.py") | crontab
+CMD ["crond", "-f", "-d", "8"]
 EXPOSE 8000


### PR DESCRIPTION
 #### What does this PR do?
- Adds a cronjob that runs at 22:00 UTC
#### Where should the reviewer start?
`Dockerfile.yml` 

#### How should this be manually tested?
1. On your local machine run `docker-compose build`
2. Run `docker-compose up -d`
3. Wait for the db to be ready and populated by the script
4. Run `docker-compose down`
5. Run `docker-compose up -d`
6. At 22:00 UTC the scores should be automatically updated.

#### Any background context you want to provide?
This PR automates the update process of the match scores.