### PR TITLE
Update shading cells in group stage

### DIFF
--- a/world-cup-predictions-front/src/components/GroupStage.vue
+++ b/world-cup-predictions-front/src/components/GroupStage.vue
@@ -21,12 +21,14 @@
             </template>
             <template slot="items" slot-scope="props">
               <tr class="wcp-group-table-row border-0">
+                <!-- Flag and Name Cell -->
                 <td class="pr-0">
                   <div
                     :class="['wcp-flag', 'flag-icon', 'flag-icon-' + props.item.flag_code]"
                   ></div>
                   <span class="wcp-group-table-title">{{ props.item.name }}</span>
                 </td>
+                <!-- Advance Cell -->
                 <td class="wcp-group-table-cell text-xs-center border-r-1">
                   <div
                     class="wcp-group-table-cell-text"
@@ -42,25 +44,27 @@
                   }}
                   </div>
                 </td>
+                <!-- Advance Second Cell -->
                 <td class=" wcp-group-table-cell text-xs-center">
                   <div
                     class="wcp-group-table-cell-text"
                     :class="{
-                      active: props.item.shaded,
-                      'active-text': props.item.shaded && !props.item.is_group_winner,
-                      'grey--text text--darken-1': !props.item.shaded || props.item.is_group_winner
+                      active: props.item.second || props.item.first,
+                      'active-text': props.item.second,
+                      'grey--text text--darken-1': !props.item.second
                     }"
                   >
                   {{ props.item.pass_group_runner_prob | percentage }}
                   </div>
                 </td>
+                <!-- Advance First Cell -->
                 <td class="wcp-group-table-cell text-xs-center">
                   <div
                     class="wcp-group-table-cell-text"
                     :class="{
-                      active: props.item.shaded && props.item.is_group_winner,
-                      'active-text': props.item.shaded && props.item.is_group_winner,
-                      'grey--text text--darken-1': !props.item.shaded || !props.item.is_group_winner
+                      active: props.item.first,
+                      'active-text': props.item.first,
+                      'grey--text text--darken-1': !props.item.first
                     }"
                   >
                   {{props.item.pass_group_winner_prob | percentage }}

--- a/world-cup-predictions-front/src/store/modules/team/getters.js
+++ b/world-cup-predictions-front/src/store/modules/team/getters.js
@@ -9,22 +9,6 @@ const teamsByGroup = (state) => {
     }
     groups[team.group].push(team);
   });
-
-  // Add a property to the winner of each group
-  Object.keys(groups).forEach((groupName) => {
-    const group = groups[groupName];
-
-    // eslint-disable-next-line
-    const advanceTeams = group.filter((team) => team.shaded);
-
-    // eslint-disable-next-line
-    const advanceFirst = advanceTeams.reduce((max, team) => {
-      return team.pass_group_winner_prob > max.pass_group_winner_prob
-        ? team
-        : max;
-    }, advanceTeams[0]);
-    advanceFirst.is_group_winner = true;
-  });
   return groups;
 };
 


### PR DESCRIPTION
### What does this PR do?
- Uses shading values for paint cells in the Group Stage tables

### Where should the reviewer start?
- Prediction Tool Tab > Group Stage

### How should this be manually tested?
- Spain should pass in the first place according to the model

### Any background context you want to provide?
Previously we were using the percentages of winning the group phase to shade those cells