### PR TITLE
Correct match label

### DIFF
--- a/world-cup-predictions-front/src/components/matches/MatchCard.vue
+++ b/world-cup-predictions-front/src/components/matches/MatchCard.vue
@@ -134,6 +134,11 @@ export default {
       moment.updateLocale('en', {
         relativeTime: {
           future: '%s left',
+          m: '1 minute',
+          h: '1 hour',
+          d: '1 day',
+          M: '1 month',
+          y: '1 year',
         },
       });
       const relativeTime = moment(this.match.date).fromNow();


### PR DESCRIPTION
### What does this PR do?
- Change the label of match cards from 'a day left...' to '1 day left...', 'an hour left...' to '1 hour left...', etc.

### Where should the reviewer start?
- Sign In > Prediction Game > any match card