### PR TITLE
Feat/ provide a new api for game trends

### DIFF
--- a/world-cup-predictions-back/api/models.py
+++ b/world-cup-predictions-back/api/models.py
@@ -119,7 +119,7 @@ class Vote(models.Model):
     (DRAW, 'D'),
   )
   user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='votes')
-  game = models.ForeignKey(WorldCupGame, on_delete=models.CASCADE)
+  game = models.ForeignKey(WorldCupGame, on_delete=models.CASCADE, related_name='trends')
   choice = models.CharField(
     null=True,
     max_length=1,

--- a/world-cup-predictions-back/api/serializers.py
+++ b/world-cup-predictions-back/api/serializers.py
@@ -81,3 +81,18 @@ class SocialSerializer(serializers.Serializer):
         allow_blank=False,
         trim_whitespace=True,
     )
+
+class TrendSerializer(serializers.ModelSerializer):
+    home_win_trend = serializers.SerializerMethodField()
+    away_win_trend = serializers.SerializerMethodField()
+    draw_trend = serializers.SerializerMethodField()
+    class Meta :
+        model = WorldCupGame
+        fields = ('id', 'home_win_trend', 'away_win_trend', 'draw_trend')
+
+    def get_home_win_trend(self, obj):
+        return obj.trends.filter(choice='H').count()/(User.objects.all().count() - 2)
+    def get_away_win_trend(self, obj):
+        return obj.trends.filter(choice='A').count()/(User.objects.all().count() - 2)
+    def get_draw_trend(self, obj):
+        return obj.trends.filter(choice='D').count()/(User.objects.all().count() - 2)

--- a/world-cup-predictions-back/api/urls.py
+++ b/world-cup-predictions-back/api/urls.py
@@ -15,6 +15,7 @@ router.register(r'vote', views.VoteViewSet, 'votes')
 router.register(r'leaderboard', views.LeaderboardViewSet)
 router.register(r'myleaderboard', views.MyCustomLeaderboardViewSet, 'myleaderboard')
 router.register(r'topcontenders', views.TopContendersViewSet)
+router.register(r'trend', views.TrendViewSet)
 # The API URLs are now determined automatically by the router.
 # Additionally, we include the login URLs for the browsable API.
 urlpatterns = [

--- a/world-cup-predictions-back/api/views.py
+++ b/world-cup-predictions-back/api/views.py
@@ -18,7 +18,7 @@ from social_django.utils import psa
 import pandas as pd
 
 from api.models import HistoricalGame, Team, Group, WorldCupGame, Prediction, Vote, User
-from api.serializers import HistoricalGameSerializer, TeamSerializer, GroupSerializer, WorldCupGameSerializer, PredictionSerializer, VoteSerializer, UserSerializer, SocialSerializer, LeaderboardSerializer
+from api.serializers import HistoricalGameSerializer, TeamSerializer, GroupSerializer, WorldCupGameSerializer, PredictionSerializer, VoteSerializer, UserSerializer, SocialSerializer, LeaderboardSerializer, TrendSerializer
 from model.worldcup_predictor import predict_group_match, get_defense_capabilities, win_knockout_match, fetch_matches
 from update_paul_user import get_paul_choice
 
@@ -174,6 +174,11 @@ class MyCustomLeaderboardViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         return self.request.user.following.all()
 
+class TrendViewSet(viewsets.ModelViewSet):
+    queryset = WorldCupGame.objects.all()
+    serializer_class = TrendSerializer
+    permission_classes = (permissions.IsAuthenticated, )
+    http_method_names = ['get']
 
 @api_view(http_method_names=['POST'])
 @permission_classes([AllowAny])


### PR DESCRIPTION
## What does this PR do ? 
- creates a new api `trend` which provides three values for each game : 
 -- `home_win_trend` : the fraction of wizeliners guessed that the home team will win a certain game.
 --  `away_win_trend` : the fraction of wizeliners guessed that the away team will win a certain game.
 --  `draw_trend` : the fraction of wizeliners guessed that the a certain game will be a tie.

- the api should used as follows : 
 -- `GET .../api/trend` to get trends for all games.
 -- `GET .../api/trend/{game_id}` to get trends for a certain game.